### PR TITLE
Проблема соединения с Github

### DIFF
--- a/LR/07/src/config/authorizarionCredentials.xml
+++ b/LR/07/src/config/authorizarionCredentials.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<credentials username="None-stopCoding" token="9f2e6dca801ef883a1948337fc8d3ab0f6900777"></credentials>

--- a/LR/07/src/config/authorizarionCredentials.xml
+++ b/LR/07/src/config/authorizarionCredentials.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<credentials username="None-stopCoding" token="9f2e6dca801ef883a1948337fc8d3ab0f6900777"></credentials>

--- a/LR/07/src/functional.cpp
+++ b/LR/07/src/functional.cpp
@@ -1,57 +1,13 @@
 #include "functional.h"
 
 /**
- * @brief Авторизация на Guthub и доступ к Github API осуществляется
- * через Basic Authorization. Для этого в заголовках к каждому запросу
- * наобходимо дабовалять соответствующую информацию. Пример GET запроса:
- *      QNetworkRequest request = QNetworkRequest(QUrl("http://192.168.1.10/getinfo"));
- *      request.setRawHeader("Authorization", headerData.toLocal8Bit());
- *      networkAccessManager->get(request);
+ * @brief Конструктор
  * @param parent - родитель этого класса, базовый QObject
  */
 Functional::Functional(QObject *parent)
     : QObject(parent)
 {
     manager = new QNetworkAccessManager();
-
-    QString userName, token;
-    getCredentials("/config/authorizarionCredentials.xml", &userName, &token);
-    setAuthorizationHeaderData(userName, token);
-}
-
-/**
- * @brief Получает из xml конфига данные для Basic-авторизации
- * @param fileName - имя файла конфига
- * @param userName - имя пользователя
- * @param personalToken - персональный токен пользователя
- */
-void Functional::getCredentials(QString fileName, QString *userName, QString *personalToken)
-{
-    QDomDocument domDoc;
-    QFile file(":" + fileName);
-
-    if (file.open(QIODevice::ReadOnly)) {
-        if (domDoc.setContent(&file)) {
-            QDomElement base = domDoc.documentElement();
-            if (base.tagName() == "credentials") {
-                (*userName) = base.attribute("username", "");
-                (*personalToken) = base.attribute("token", "");
-            }
-        }
-        file.close();
-    }
-}
-
-/**
- * @brief Устанавливает в заголовки данные для Basic-авторизации
- * @param userName
- * @param personalToken
- */
-void Functional::setAuthorizationHeaderData(QString userName, QString personalToken)
-{
-    QString secretData = userName + ":" + personalToken;
-    QByteArray encodedData = secretData.toLocal8Bit().toBase64();
-    headerData = "Basic " + encodedData;
 }
 
 /**

--- a/LR/07/src/functional.h
+++ b/LR/07/src/functional.h
@@ -7,9 +7,6 @@
 #include <QNetworkReply>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QUrl>
-#include <QFile>
-#include <QDomDocument>
 
 /**
  * @brief Класс для получения листинга кода с GitHub
@@ -31,10 +28,6 @@ public:
     void getContentFromGithub();
     void dataProcessing();
     void getLinkToFile();
-
-private:
-    void setAuthorizationHeaderData(QString, QString);
-    void getCredentials(QString, QString*, QString*);
 };
 
 #endif // FUNCTIONAL_H

--- a/LR/07/src/functional.h
+++ b/LR/07/src/functional.h
@@ -7,6 +7,9 @@
 #include <QNetworkReply>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUrl>
+#include <QFile>
+#include <QDomDocument>
 
 /**
  * @brief Класс для получения листинга кода с GitHub
@@ -20,17 +23,18 @@ public:
 
 private:
     QNetworkAccessManager *manager;
-    QString link;
-    QString secretToken;
+    QString headerData;
 
 public:
-    explicit Functional(QString linkFromServer, QObject *parent = nullptr);
+    explicit Functional(QObject *parent = nullptr);
+    ~Functional();
     void getContentFromGithub();
     void dataProcessing();
     void getLinkToFile();
 
 private:
-    QString authorize();
+    void setAuthorizationHeaderData(QString, QString);
+    void getCredentials(QString, QString*, QString*);
 };
 
 #endif // FUNCTIONAL_H

--- a/LR/07/src/resources.qrc
+++ b/LR/07/src/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
     <qresource prefix="/">
-        <file>config/authorizarionCredentials.xml</file>
+        <file>config/answerStructure.xml</file>
     </qresource>
 </RCC>

--- a/LR/07/src/resources.qrc
+++ b/LR/07/src/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>config/authorizarionCredentials.xml</file>
+    </qresource>
+</RCC>

--- a/LR/07/src/src.pro
+++ b/LR/07/src/src.pro
@@ -34,3 +34,6 @@ HEADERS += \
 
 win32:CONFIG += console
 win32:TARGET  = ../XmlDOMRead
+
+RESOURCES += \
+    resources.qrc

--- a/LR/07/src/src.pro
+++ b/LR/07/src/src.pro
@@ -1,6 +1,5 @@
 QT -= gui
-QT += network
-QT += xml
+QT += network xml
 
 CONFIG += c++11 console
 CONFIG -= app_bundle

--- a/LR/07/src/tcpserver.cpp
+++ b/LR/07/src/tcpserver.cpp
@@ -86,7 +86,7 @@ void TcpServer::slotReadingDataJson()
         if (docJsonError.errorString().toInt() == QJsonParseError::NoError) {
             try {
                 if (parsingJson(docJson, &labLink, &labNumber, &pureCode)) {
-                    githubManager = new Functional(labLink);
+                    githubManager = new Functional();
                 }
 
                 lab = new StrategyLab(labNumber);


### PR DESCRIPTION
Возникшая проблема соединения с Github (#335) никак не связана с авторизацией. В результате было принято решение отказаться от авторизации в принципе, так как для работы с теми областями Github, с которыми мы планируем связываться, авторизация не нужна. "TSL initialization failed" проблема связана с неверным default подгружаемыми файлами библиотеки OpenSSL. После установки нужной версии (OpenSSL-Win32)  связь с Github устанавливается и можно обмениваться информацией.