### PR TITLE
Добавлен .dat файл для unit-test отчетов

### DIFF
--- a/LR/07/Tests/test.dat
+++ b/LR/07/Tests/test.dat
@@ -1,0 +1,26 @@
+QT += testlib
+QT -= gui
+QT += network
+QT += xml
+LIBS += -lgcov
+
+QMAKE_CXXFLAGS += -g -fprofile-arcs -ftest-coverage -O0
+QMAKE_LFLAGS += -g -fprofile-arcs -ftest-coverage  -O0
+
+HEADERS += \
+    ../src/functional.h \
+    ../src/strategylab.h \
+    ../src/tcpserver.h \
+    testtcp.h
+
+SOURCES += \
+    ../src/functional.cpp \
+    ../src/strategylab.cpp \
+    ../src/tcpserver.cpp \
+    testtcp.cpp
+
+SUBDIRS += \
+    ../src/src.pro
+
+DISTFILES += \
+    ../src/config/answerStructure.xml


### PR DESCRIPTION
Это temp версия файла "test.pro" создана для построения отчетов на Linux. Создана для удобства всей команды

- Чтобы не рушить сборку у всех, т.к. на Windows не компилится

- Удобство. Незаменимая вещь у тестировщика, ему лишь достаточно склонить весь проект к себе и переименовать, чем качать каждый раз вручную заново и откуда-то

- Нужна только для построения отчетов, никакого участия в тестах не принимает.
closes #241 