### PR TITLE
fix import logging_config

### DIFF
--- a/email/18-ISbo-2a/mainp/log_method.py
+++ b/email/18-ISbo-2a/mainp/log_method.py
@@ -1,8 +1,6 @@
-import configparser
+import logging_config as config
 import logging
 
-config = configparser.RawConfigParser()
-config.read('logging_config.conf')
 levels = {
     'DEBUG': logging.DEBUG,
     'INFO': logging.INFO,
@@ -11,9 +9,9 @@ levels = {
     'CRITICAL': logging.CRITICAL
 }
 logging.basicConfig(
-    filename=config['DEFAULT']['file'],
-    level=levels[config['DEFAULT']['level']],
-    format=config['DEFAULT']['format'])
+    filename=config.filename,
+    level=levels[config.level],
+    format=config.format)
 
 logger = logging.getLogger(__name__)
 

--- a/email/18-ISbo-2a/mainp/logging_config.conf
+++ b/email/18-ISbo-2a/mainp/logging_config.conf
@@ -1,4 +1,0 @@
-[DEFAULT]
-level=DEBUG
-format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
-file=product_logs.log

--- a/email/18-ISbo-2a/mainp/logging_config.py
+++ b/email/18-ISbo-2a/mainp/logging_config.py
@@ -1,0 +1,3 @@
+filename = "product_logs.log"
+level = "DEBUG"
+format = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
Проблема заключалась в том, что python не мог по каким-то непонятным причинам импортировать logging_config.conf. Я не нашел другого решения, как перенести файл конфига в python файл. Данная ошибка возникала и ранее, но только в visual studio code, а в cmd все импортировало.